### PR TITLE
Fix Mummy and Parental Bond Interaction (#4890)

### DIFF
--- a/data/abilities.js
+++ b/data/abilities.js
@@ -2050,6 +2050,9 @@ let BattleAbilities = {
 				}
 			}
 		},
+		onBasePower: function (basePower, pokemon, target, move) {
+			if (move.multihitType === 'parentalbond' && move.hit > 1) return this.chainModify(0.25);
+		},
 		rating: 2,
 		num: 152,
 	},


### PR DESCRIPTION
Problem: Parental Bond when changed to Mummy midstrike would cause the second move to miss the .25 base power modification
Added Parental Bond check in Mummy to maintain the power modification